### PR TITLE
NullPointerException on nodes call when there are deleted nodes in the result

### DIFF
--- a/src/main/java/de/westnordost/osmapi/map/MapDataFactory.java
+++ b/src/main/java/de/westnordost/osmapi/map/MapDataFactory.java
@@ -1,19 +1,15 @@
 package de.westnordost.osmapi.map;
 
+import de.westnordost.osmapi.changesets.Changeset;
+import de.westnordost.osmapi.map.data.*;
+
 import java.util.List;
 import java.util.Map;
-
-import de.westnordost.osmapi.changesets.Changeset;
-import de.westnordost.osmapi.map.data.Element;
-import de.westnordost.osmapi.map.data.Node;
-import de.westnordost.osmapi.map.data.Relation;
-import de.westnordost.osmapi.map.data.RelationMember;
-import de.westnordost.osmapi.map.data.Way;
 
 public interface MapDataFactory
 {	
 	/** Create a node from the given data */
-	Node createNode(long id, int version, double lat, double lon, Map<String,String> tags, 
+	Node createNode(long id, int version, Double lat, Double lon, Map<String,String> tags,
 			Changeset changeset);
 	
 	/** Create a way from the given data */

--- a/src/main/java/de/westnordost/osmapi/map/MapDataParser.java
+++ b/src/main/java/de/westnordost/osmapi/map/MapDataParser.java
@@ -1,24 +1,18 @@
 package de.westnordost.osmapi.map;
 
-import java.io.InputStream;
-import java.text.ParseException;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-
 import de.westnordost.osmapi.ApiResponseReader;
+import de.westnordost.osmapi.changesets.Changeset;
+import de.westnordost.osmapi.common.OsmXmlDateFormat;
+import de.westnordost.osmapi.common.XmlParser;
 import de.westnordost.osmapi.map.data.BoundingBox;
 import de.westnordost.osmapi.map.data.Element;
 import de.westnordost.osmapi.map.data.RelationMember;
 import de.westnordost.osmapi.map.handler.MapDataHandler;
-import de.westnordost.osmapi.changesets.Changeset;
-import de.westnordost.osmapi.common.OsmXmlDateFormat;
-import de.westnordost.osmapi.common.XmlParser;
 import de.westnordost.osmapi.user.User;
+
+import java.io.InputStream;
+import java.text.ParseException;
+import java.util.*;
 
 /** Parses the map data. It parses the XML naively, i.e. it does not care where in the XML the map
  *  data is. */
@@ -41,8 +35,8 @@ public class MapDataParser extends XmlParser implements ApiResponseReader<Void>
 	private int version = 0;
 	Long changesetId;
 
-	private double lat;
-	private double lon;
+	private Double lat;
+	private Double lon;
 	private Map<String, String> tags;
 	private List<RelationMember> members;
 	private List<Long> nodes;

--- a/src/main/java/de/westnordost/osmapi/map/OsmMapDataFactory.java
+++ b/src/main/java/de/westnordost/osmapi/map/OsmMapDataFactory.java
@@ -1,23 +1,16 @@
 package de.westnordost.osmapi.map;
 
-import java.util.List;
-import java.util.Map;
-
 import de.westnordost.osmapi.changesets.Changeset;
 import de.westnordost.osmapi.map.data.Element.Type;
-import de.westnordost.osmapi.map.data.Node;
-import de.westnordost.osmapi.map.data.OsmNode;
-import de.westnordost.osmapi.map.data.OsmRelation;
-import de.westnordost.osmapi.map.data.OsmRelationMember;
-import de.westnordost.osmapi.map.data.OsmWay;
-import de.westnordost.osmapi.map.data.Relation;
-import de.westnordost.osmapi.map.data.RelationMember;
-import de.westnordost.osmapi.map.data.Way;
+import de.westnordost.osmapi.map.data.*;
+
+import java.util.List;
+import java.util.Map;
 
 public class OsmMapDataFactory implements MapDataFactory
 {
 	@Override
-	public Node createNode(long id, int version, double lat, double lon, Map<String, String> tags,
+	public Node createNode(long id, int version, Double lat, Double lon, Map<String, String> tags,
 			Changeset changeset)
 	{
 		return new OsmNode(id, version, lat, lon, tags, changeset);

--- a/src/main/java/de/westnordost/osmapi/map/changes/MapDataChangesWriter.java
+++ b/src/main/java/de/westnordost/osmapi/map/changes/MapDataChangesWriter.java
@@ -140,10 +140,8 @@ public class MapDataChangesWriter extends XmlWriter
 	private void writeNodeContents(Node node) throws IOException
 	{
 		LatLon position = node.getPosition();
-		if (position != null) {
-			attribute("lat", position.getLatitude());
-			attribute("lon", position.getLongitude());
-		}
+		attribute("lat", position.getLatitude());
+		attribute("lon", position.getLongitude());
 	}
 
 	private void writeWayContents(Way way) throws IOException

--- a/src/main/java/de/westnordost/osmapi/map/changes/MapDataChangesWriter.java
+++ b/src/main/java/de/westnordost/osmapi/map/changes/MapDataChangesWriter.java
@@ -1,19 +1,10 @@
 package de.westnordost.osmapi.map.changes;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-
 import de.westnordost.osmapi.common.XmlWriter;
-import de.westnordost.osmapi.map.data.Element;
-import de.westnordost.osmapi.map.data.LatLon;
-import de.westnordost.osmapi.map.data.Node;
-import de.westnordost.osmapi.map.data.Relation;
-import de.westnordost.osmapi.map.data.RelationMember;
-import de.westnordost.osmapi.map.data.Way;
+import de.westnordost.osmapi.map.data.*;
+
+import java.io.IOException;
+import java.util.*;
 
 /** Writes elements into a osmChange format */
 public class MapDataChangesWriter extends XmlWriter
@@ -149,8 +140,10 @@ public class MapDataChangesWriter extends XmlWriter
 	private void writeNodeContents(Node node) throws IOException
 	{
 		LatLon position = node.getPosition();
-		attribute("lat", position.getLatitude());
-		attribute("lon", position.getLongitude());
+		if (position != null) {
+			attribute("lat", position.getLatitude());
+			attribute("lon", position.getLongitude());
+		}
 	}
 
 	private void writeWayContents(Way way) throws IOException

--- a/src/main/java/de/westnordost/osmapi/map/data/OsmNode.java
+++ b/src/main/java/de/westnordost/osmapi/map/data/OsmNode.java
@@ -1,19 +1,21 @@
 package de.westnordost.osmapi.map.data;
 
-import java.util.Map;
-
 import de.westnordost.osmapi.changesets.Changeset;
+
+import java.util.Map;
 
 public class OsmNode extends OsmElement implements Node
 {
 	private boolean modified;
 	private LatLon pos;
 
-	public OsmNode(long id, int version, double lat, double lon,
+	public OsmNode(long id, int version, Double lat, Double lon,
 			   Map<String, String> tags, Changeset changeset)
 {
 	super(id, version, tags, changeset);
-	this.pos = new OsmLatLon(lat,lon);
+	if (lat != null && lon != null) {
+		this.pos = new OsmLatLon(lat, lon);
+	}
 }
 	
 	public OsmNode(long id, int version, LatLon pos,

--- a/src/test/java/de/westnordost/osmapi/map/MapDataParserTest.java
+++ b/src/test/java/de/westnordost/osmapi/map/MapDataParserTest.java
@@ -222,6 +222,14 @@ public class MapDataParserTest extends TestCase
 		assertSame(elements.get(0).getChangeset().user, elements.get(1).getChangeset().user);
 	}
 
+	public void testDeletedNode() {
+		String xml = "<node id=\"5\" visible=\"false\" version=\"4\" changeset=\"9249514\" " +
+							"timestamp=\"2011-09-08T21:13:24Z\" user=\"mattfromderby\" uid=\"15867\"/>";
+		Node node = parseOne(xml, Node.class);
+		assertNotNull(node);
+		assertNull(node.getPosition());
+	}
+
 	private List<Element> parseList(String xml)
 	{
 		ListOsmElementHandler<Element> handler = new ListOsmElementHandler<>(Element.class);

--- a/src/test/java/de/westnordost/osmapi/map/changes/MapDataChangesWriterTest.java
+++ b/src/test/java/de/westnordost/osmapi/map/changes/MapDataChangesWriterTest.java
@@ -147,6 +147,17 @@ public class MapDataChangesWriterTest extends TestCase
 		assertFalse(writer.hasChanges());
 	}
 
+    public void testWriteNodeWithoutPosition() throws Exception {
+        try {
+            OsmNode element = createNode(-1);
+            element.setPosition(null);
+            writeXml(1, element);
+            fail();
+        } catch (NullPointerException e) {
+            // expected
+        }
+    }
+
 	private static String writeXml(long changesetId, Element singleElement) throws IOException
 	{
 		List<Element> elements = new ArrayList<>(1);


### PR DESCRIPTION
I've changed the lat and lon type from double to Double, so it won't throw an exception when there are no such fields from the result.
