### PR TITLE
Implement GDPR-related changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ build
 .classpath
 .settings
 gradle-app.setting
+/.idea/
+/local.properties

--- a/src/main/java/de/westnordost/osmapi/OsmConnection.java
+++ b/src/main/java/de/westnordost/osmapi/OsmConnection.java
@@ -143,6 +143,12 @@ public class OsmConnection
 	}
 
 	/** @see #makeRequest(String, String, boolean, ApiRequestWriter, ApiResponseReader)*/
+	public <T> T makeRequest(String call, boolean authenticate, ApiResponseReader<T> reader)
+	{
+		return makeRequest(call, null, authenticate, null, reader);
+	}
+
+	/** @see #makeRequest(String, String, boolean, ApiRequestWriter, ApiResponseReader)*/
 	public <T> T  makeAuthenticatedRequest(String call, String method, ApiResponseReader<T> reader)
 	{
 		return makeRequest(call, method, true, null, reader);

--- a/src/main/java/de/westnordost/osmapi/changesets/ChangesetsDao.java
+++ b/src/main/java/de/westnordost/osmapi/changesets/ChangesetsDao.java
@@ -29,6 +29,7 @@ public class ChangesetsDao
 	/** Get the changeset information with the given id. Always includes the changeset discussion.
 	 *
 	 * @param id changeset id
+	 * @throws OsmAuthorizationException if not logged in
 	 * @return info for the given changeset. Null if it does not exist. */
 	public ChangesetInfo get(long id)
 	{
@@ -36,7 +37,7 @@ public class ChangesetsDao
 		String query = CHANGESET + "/" + id + "?include_discussion=true";
 		try
 		{
-			osm.makeRequest(query, new ChangesetParser(handler));
+			osm.makeAuthenticatedRequest(query, null, new ChangesetParser(handler));
 		}
 		catch(OsmNotFoundException e)
 		{
@@ -49,13 +50,15 @@ public class ChangesetsDao
 	 *
 	 *  @param handler The handler which is fed the incoming changeset infos
 	 *  @param filters what to search for. I.e.
-	 *                 new QueryChangesetsFilters().byUser(123).onlyClosed() */
+	 *                 new QueryChangesetsFilters().byUser(123).onlyClosed()
+	 *
+	 *	@throws OsmAuthorizationException if not logged in */
 	public void find(Handler<ChangesetInfo> handler, QueryChangesetsFilters filters)
 	{
 		String query = filters != null ? "?" + filters.toParamString() : "";
 		try
 		{
-			osm.makeRequest(CHANGESET + "s" + query, new ChangesetParser(handler));
+			osm.makeAuthenticatedRequest(CHANGESET + "s" + query, null, new ChangesetParser(handler));
 		}
 		catch(OsmNotFoundException e)
 		{
@@ -174,6 +177,7 @@ public class ChangesetsDao
 		return result;
 	}
 
+	// TODO GDPR anonymous access still possible?
 	/**
 	 * Get map data changes associated with the given changeset, using the default OsmMapDataFactory
 	 * 
@@ -183,9 +187,10 @@ public class ChangesetsDao
 	{
 		getData(id, handler, new OsmMapDataFactory());
 	}
-	
+
+	// TODO GDPR anonymous access still possible?
 	/**
-	 * Get map data changes associated with the given changeset. 
+	 * Get map data changes associated with the given changeset.
 	 * 
 	 * @throws OsmNotFoundException if changeset with the given id does not exist
 	 */

--- a/src/main/java/de/westnordost/osmapi/changesets/ChangesetsDao.java
+++ b/src/main/java/de/westnordost/osmapi/changesets/ChangesetsDao.java
@@ -14,7 +14,8 @@ import de.westnordost.osmapi.map.OsmMapDataFactory;
 import de.westnordost.osmapi.map.changes.MapDataChangesHandler;
 import de.westnordost.osmapi.map.changes.MapDataChangesParser;
 
-/** Gets information for, searches for and shows changeset discussions. */
+/** Gets information for, searches for and shows changeset discussions.
+ *  All interactions with this class require an OsmConnection with a logged in user. */
 public class ChangesetsDao
 {
 	private static final String CHANGESET = "changeset";
@@ -177,7 +178,6 @@ public class ChangesetsDao
 		return result;
 	}
 
-	// TODO GDPR anonymous access still possible?
 	/**
 	 * Get map data changes associated with the given changeset, using the default OsmMapDataFactory
 	 * 
@@ -188,15 +188,15 @@ public class ChangesetsDao
 		getData(id, handler, new OsmMapDataFactory());
 	}
 
-	// TODO GDPR anonymous access still possible?
 	/**
 	 * Get map data changes associated with the given changeset.
-	 * 
+	 *
+	 * @throws OsmAuthorizationException if not logged in
 	 * @throws OsmNotFoundException if changeset with the given id does not exist
 	 */
 	public void getData(long id, MapDataChangesHandler handler, MapDataFactory factory)
 	{
-		osm.makeRequest(CHANGESET + "/" + id + "/download",
+		osm.makeAuthenticatedRequest(CHANGESET + "/" + id + "/download", null,
 				new MapDataChangesParser(handler, factory));
 	}
 

--- a/src/main/java/de/westnordost/osmapi/map/MapDataHistoryDao.java
+++ b/src/main/java/de/westnordost/osmapi/map/MapDataHistoryDao.java
@@ -40,53 +40,71 @@ public class MapDataHistoryDao
 	}
 
 	/** Feeds all versions of the given node to the handler. The elements are sorted by version,
-	 *  the oldest version is the first, the newest version is the last element.
+	 *  the oldest version is the first, the newest version is the last element.<br/>
+	 *  Note that the changeset information for each returned node will only include the user
+	 *  information if logged in.
 	 *
 	 * @throws OsmNotFoundException if the node has not been found. */
 	public void getNodeHistory(long id, Handler<Node> handler)
 	{
 		MapDataHandler mapDataHandler = new WrapperOsmElementHandler<>(Node.class, handler);
-		osm.makeRequest(NODE + "/" + id + "/" + HISTORY,
+		boolean authenticate = osm.getOAuth() != null;
+		osm.makeRequest(NODE + "/" + id + "/" + HISTORY, authenticate,
 				new MapDataParser(mapDataHandler, factory));
 	}
 
 	/** Feeds all versions of the given way to the handler. The elements are sorted by version,
-	 *  the oldest version is the first, the newest version is the last element.
+	 *  the oldest version is the first, the newest version is the last element.<br/>
+	 *  Note that the changeset information for each returned way will only include the user
+	 *  information if logged in.
 	 *
 	 * @throws OsmNotFoundException if the node has not been found. */
 	public void getWayHistory(long id, Handler<Way> handler)
 	{
 		MapDataHandler mapDataHandler = new WrapperOsmElementHandler<>(Way.class, handler);
-		osm.makeRequest(WAY + "/" + id + "/" + HISTORY,
+		boolean authenticate = osm.getOAuth() != null;
+		osm.makeRequest(WAY + "/" + id + "/" + HISTORY, authenticate,
 				new MapDataParser(mapDataHandler, factory));
 	}
 
 	/** Feeds all versions of the given relation to the handler. The elements are sorted by version,
-	 *  the oldest version is the first, the newest version is the last element.
+	 *  the oldest version is the first, the newest version is the last element.<br/>
+	 *  Note that the changeset information for each returned relation will only include the user
+	 *  information if logged in.
 	 *
 	 * @throws OsmNotFoundException if the node has not been found. */
 	public void getRelationHistory(long id, Handler<Relation> handler)
 	{
 		MapDataHandler mapDataHandler = new WrapperOsmElementHandler<>(Relation.class, handler);
-		osm.makeRequest(RELATION + "/" + id + "/" + HISTORY,
+		boolean authenticate = osm.getOAuth() != null;
+		osm.makeRequest(RELATION + "/" + id + "/" + HISTORY, authenticate,
 				new MapDataParser(mapDataHandler, factory));
 	}
 
-	/** @return the given version of the given element or null if either the node or given the version
+	/** Note that the changeset information for the returned node will only include the user
+	 *  information if logged in.
+	 *
+	 *  @return the given version of the given element or null if either the node or given the version
 	 *          of the node does not exist (anymore).  */
 	public Node getNodeVersion(long id, int version)
 	{
 		return getElementVersion(NODE + "/" + id + "/" + version, Node.class);
 	}
 
-	/** @return the given version of the given element or null if either the node or given the version
+	/** Note that the changeset information for the returned way will only include the user
+	 *  information if logged in.
+	 *
+	 *  @return the given version of the given element or null if either the node or given the version
 	 *          of the node does not exist (anymore).  */
 	public Way getWayVersion(long id, int version)
 	{
 		return getElementVersion(WAY + "/" + id + "/" + version, Way.class);
 	}
 
-	/** @return the given version of the given element or null if either the node or given the version
+	/** Note that the changeset information for the returned relation will only include the user
+	 *  information if logged in.
+	 *
+	 *  @return the given version of the given element or null if either the node or given the version
 	 *          of the node does not exist (anymore).  */
 	public Relation getRelationVersion(long id, int version)
 	{
@@ -98,7 +116,8 @@ public class MapDataHistoryDao
 		SingleOsmElementHandler<T> handler = new SingleOsmElementHandler<>(tClass);
 		try
 		{
-			osm.makeRequest(call, new MapDataParser(handler, factory));
+			boolean authenticate = osm.getOAuth() != null;
+			osm.makeRequest(call, authenticate, new MapDataParser(handler, factory));
 		}
 		catch(OsmApiException e)
 		{

--- a/src/main/java/de/westnordost/osmapi/map/MapDataHistoryDao.java
+++ b/src/main/java/de/westnordost/osmapi/map/MapDataHistoryDao.java
@@ -41,8 +41,7 @@ public class MapDataHistoryDao
 
 	/** Feeds all versions of the given node to the handler. The elements are sorted by version,
 	 *  the oldest version is the first, the newest version is the last element.<br/>
-	 *  Note that the changeset information for each returned node will only include the user
-	 *  information if logged in.
+	 *  If not logged in, the Changeset for each returned element will be null
 	 *
 	 * @throws OsmNotFoundException if the node has not been found. */
 	public void getNodeHistory(long id, Handler<Node> handler)
@@ -55,8 +54,7 @@ public class MapDataHistoryDao
 
 	/** Feeds all versions of the given way to the handler. The elements are sorted by version,
 	 *  the oldest version is the first, the newest version is the last element.<br/>
-	 *  Note that the changeset information for each returned way will only include the user
-	 *  information if logged in.
+	 *  If not logged in, the Changeset for each returned element will be null
 	 *
 	 * @throws OsmNotFoundException if the node has not been found. */
 	public void getWayHistory(long id, Handler<Way> handler)
@@ -69,8 +67,7 @@ public class MapDataHistoryDao
 
 	/** Feeds all versions of the given relation to the handler. The elements are sorted by version,
 	 *  the oldest version is the first, the newest version is the last element.<br/>
-	 *  Note that the changeset information for each returned relation will only include the user
-	 *  information if logged in.
+	 *  If not logged in, the Changeset for each returned element will be null
 	 *
 	 * @throws OsmNotFoundException if the node has not been found. */
 	public void getRelationHistory(long id, Handler<Relation> handler)
@@ -81,8 +78,7 @@ public class MapDataHistoryDao
 				new MapDataParser(mapDataHandler, factory));
 	}
 
-	/** Note that the changeset information for the returned node will only include the user
-	 *  information if logged in.
+	/** Note that if not logged in, the Changeset for each returned element will be null
 	 *
 	 *  @return the given version of the given element or null if either the node or given the version
 	 *          of the node does not exist (anymore).  */
@@ -91,8 +87,7 @@ public class MapDataHistoryDao
 		return getElementVersion(NODE + "/" + id + "/" + version, Node.class);
 	}
 
-	/** Note that the changeset information for the returned way will only include the user
-	 *  information if logged in.
+	/** Note that if not logged in, the Changeset for each returned element will be null
 	 *
 	 *  @return the given version of the given element or null if either the node or given the version
 	 *          of the node does not exist (anymore).  */
@@ -101,8 +96,7 @@ public class MapDataHistoryDao
 		return getElementVersion(WAY + "/" + id + "/" + version, Way.class);
 	}
 
-	/** Note that the changeset information for the returned relation will only include the user
-	 *  information if logged in.
+	/** Note that if not logged in, the Changeset for each returned element will be null
 	 *
 	 *  @return the given version of the given element or null if either the node or given the version
 	 *          of the node does not exist (anymore).  */
@@ -121,7 +115,7 @@ public class MapDataHistoryDao
 		}
 		catch(OsmApiException e)
 		{
-			/** if a version of an element has been redacted, the api will send back a 403
+			/* if a version of an element has been redacted, the api will send back a 403
 			 *  forbidden error instead of a 404. Since for the user, this is just a "it's not
 			 *  there" because he has no way to acquire redacted versions, it should just return
 			 *  null. The error code between "version does not exist" and "element does not exist"

--- a/src/main/java/de/westnordost/osmapi/notes/NotesDao.java
+++ b/src/main/java/de/westnordost/osmapi/notes/NotesDao.java
@@ -15,7 +15,8 @@ import de.westnordost.osmapi.OsmConnection;
 import de.westnordost.osmapi.map.data.BoundingBox;
 import de.westnordost.osmapi.map.data.LatLon;
 
-/** Creates, comments, closes, reopens and search for notes */
+/** Creates, comments, closes, reopens and search for notes
+ *  All interactions with this class require an OsmConnection with a logged in user. */
 public class NotesDao
 {
 	private static final String NOTES = "notes";
@@ -28,34 +29,17 @@ public class NotesDao
 	}
 
 	/**
-	 * Create a new note at the given location as the current user or anonymous if not logged in.
-	 *
-	 * @param pos position of the note. Must not be null.
-	 * @param text text for the new note. Must not be empty nor null.
-	 * @throws OsmAuthorizationException if this application is not authorized to write notes
-	 *                                    (Permission.WRITE_NOTES)
-	 * @return the new note
-	 */
-	public Note create(LatLon pos, String text)
-	{
-		boolean asAnonymous = osm.getOAuth() == null;
-		return create(pos, text, asAnonymous);
-	}
-
-	// TODO GDPR posting as anonymous still allowed?
-	/**
 	 * Create a new note at the given location
 	 *
 	 * @param pos position of the note. Must not be null.
 	 * @param text text for the new note. Must not be empty nor null.
-	 * @param asAnonymous whether to post this note as anonymous
 	 *
 	 * @throws OsmAuthorizationException if this application is not authorized to write notes
-	 *                                    (Permission.WRITE_NOTES) - and posting as non anonymous
+	 *                                   (Permission.WRITE_NOTES)
 	 *
 	 * @return the new note
 	 */
-	public Note create(LatLon pos, String text, boolean asAnonymous)
+	public Note create(LatLon pos, String text)
 	{
 		if(text.isEmpty())
 		{
@@ -67,7 +51,7 @@ public class NotesDao
 		String call = NOTES + "?" + data;
 
 		SingleElementHandler<Note> noteHandler = new SingleElementHandler<>();
-		osm.makeRequest(call, "POST", !asAnonymous, null, new NotesParser(noteHandler));
+		osm.makeAuthenticatedRequest(call, "POST", new NotesParser(noteHandler));
 		return noteHandler.get();
 	}
 
@@ -77,7 +61,7 @@ public class NotesDao
 	 *
 	 * @throws OsmConflictException if the note has already been closed.
 	 * @throws OsmAuthorizationException if this application is not authorized to write notes
-	 *                                    (Permission.WRITE_NOTES)
+	 *                                   (Permission.WRITE_NOTES)
 	 * @throws OsmNotFoundException if the note with the given id does not exist (anymore)
 	 *
 	 * @return the updated commented note
@@ -129,7 +113,7 @@ public class NotesDao
 	 *
 	 * @throws OsmConflictException if the note has already been closed.
 	 * @throws OsmAuthorizationException if this application is not authorized to write notes
-	 *                                    (Permission.WRITE_NOTES)
+	 *                                   (Permission.WRITE_NOTES)
 	 * @throws OsmNotFoundException if the note with the given id does not exist (anymore)
 	 *
 	 * @return the closed note
@@ -199,7 +183,7 @@ public class NotesDao
 	 * @throws OsmAuthorizationException if not logged in
 	 */
 	public void getAll(BoundingBox bounds, String search, Handler<Note> handler, int limit,
-						 int hideClosedNoteAfter)
+					   int hideClosedNoteAfter)
 	{
 		if(limit <= 0 || limit > 10000)
 		{

--- a/src/main/java/de/westnordost/osmapi/traces/GpsTracesDao.java
+++ b/src/main/java/de/westnordost/osmapi/traces/GpsTracesDao.java
@@ -39,7 +39,7 @@ public class GpsTracesDao
 	 *                                  255 characters
 	 * @throws OsmBadUserInputException if the trace is invalid
 	 * @throws OsmAuthorizationException if this application is not authorized to write traces
-	 *                                    (Permission.WRITE_GPS_TRACES)
+	 *                                   (Permission.WRITE_GPS_TRACES)
 	 */
 	public long create(
 			final String name, final GpsTraceDetails.Visibility visibility,
@@ -122,8 +122,8 @@ public class GpsTracesDao
 	 * 
 	 * @throws OsmNotFoundException if the trace with the given id does not exist
 	 * @throws OsmAuthorizationException if this application is not authorized to write traces
-	 *                                    (Permission.WRITE_GPS_TRACES)
-	 *                                    OR if the trace in question is not the user's own trace
+	 *                                   (Permission.WRITE_GPS_TRACES)
+	 *                                   OR if the trace in question is not the user's own trace
 	 * @throws IllegalArgumentException if the length of the description or any one single tag
 	 *                                  is more than 256 characters
 	 */
@@ -142,8 +142,8 @@ public class GpsTracesDao
 	 * Delete one of the user's traces
 	 * 
 	 * @throws OsmAuthorizationException if this application is not authorized to write traces
-	 *                                    (Permission.WRITE_GPS_TRACES)
-	 *                                    OR if the trace in question is not the user's own trace
+	 *                                   (Permission.WRITE_GPS_TRACES)
+	 *                                   OR if the trace in question is not the user's own trace
 	 */
 	public void delete(long id)
 	{
@@ -157,6 +157,7 @@ public class GpsTracesDao
 	 *                                   traces (Permission.READ_GPS_TRACES)
 	 *                                   OR if the trace in question is not the user's own trace 
 	 *                                   and at the same time it is not public
+	 *                                   OR if not logged in at all
 	 */
 	public GpsTraceDetails get(long id)
 	{
@@ -182,6 +183,7 @@ public class GpsTracesDao
 	 *                                   traces (Permission.READ_GPS_TRACES)
 	 *                                   OR if the trace in question is not the user's own trace and
 	 *                                   at the same time it is not public
+	 *                                   OR if not logged in at all
 	 */
 	public void getData(long id, Handler<GpsTrackpoint> handler)
 	{
@@ -190,8 +192,8 @@ public class GpsTracesDao
 	
 	/** Pass all gps traces the current user uploaded to the given handler 
 	 * 	
-	 * @throws OsmAuthorizationException if this application is not authorized to read the user's traces
-	 *                                    (Permission.READ_GPS_TRACES)
+	 * @throws OsmAuthorizationException if this application is not authorized to read the user's
+	 *                                   traces (Permission.READ_GPS_TRACES)
 	 */
 	public void getMine(Handler<GpsTraceDetails> handler)
 	{
@@ -207,7 +209,7 @@ public class GpsTracesDao
 	 *             an empty response
 	 *
 	 * @throws OsmQueryTooBigException if the bounds area is too large
-	 * @throws IllegalArgumentException if the bounds cross the 180th meridian.
+	 * @throws IllegalArgumentException if the bounds cross the 180th meridian or page is < 0
 	 */
 	public void getAll(BoundingBox bounds, Handler<GpsTrackpoint> handler, int page)
 	{

--- a/src/main/java/de/westnordost/osmapi/user/UserDao.java
+++ b/src/main/java/de/westnordost/osmapi/user/UserDao.java
@@ -4,7 +4,8 @@ import de.westnordost.osmapi.OsmConnection;
 import de.westnordost.osmapi.common.errors.OsmNotFoundException;
 import de.westnordost.osmapi.common.errors.OsmAuthorizationException;
 
-/** Get user infos and details */
+/** Get user infos and details.
+ *  All interactions with this class require an OsmConnection with a logged in user. */
 public class UserDao
 {
 	private final OsmConnection osm;

--- a/src/main/java/de/westnordost/osmapi/user/UserDao.java
+++ b/src/main/java/de/westnordost/osmapi/user/UserDao.java
@@ -19,15 +19,18 @@ public class UserDao
 	 *                                     Permission.READ_PREFERENCES_AND_USER_DETAILS*/
 	public UserDetails getMine()
 	{
-		return (UserDetails) osm.makeAuthenticatedRequest("user/details", "GET", new UserDetailsParser());
+		return (UserDetails) osm.makeAuthenticatedRequest("user/details", null, new UserDetailsParser());
 	}
 
-	/** @return the user info of the given user. Null if the user does not exist. */
+	/**
+	 * @throws OsmAuthorizationException if not logged in
+	 * @return the user info of the given user. Null if the user does not exist.
+	 *  */
 	public UserInfo get(long userId)
 	{
 		try
 		{
-			return osm.makeRequest("user/" + userId, new UserInfoParser());
+			return osm.makeAuthenticatedRequest("user/" + userId, null, new UserInfoParser());
 		}
 		catch(OsmNotFoundException e)
 		{

--- a/src/main/java/de/westnordost/osmapi/user/UserPreferencesDao.java
+++ b/src/main/java/de/westnordost/osmapi/user/UserPreferencesDao.java
@@ -16,7 +16,8 @@ import de.westnordost.osmapi.common.XmlWriter;
 import de.westnordost.osmapi.common.errors.OsmAuthorizationException;
 import de.westnordost.osmapi.common.errors.OsmNotFoundException;
 
-/** Get and set the user's custom preferences */
+/** Get and set the user's custom preferences.
+ *  All interactions with this class require an OsmConnection with a logged in user. */
 public class UserPreferencesDao
 {
 	private static final String USERPREFS = "user/preferences/";
@@ -32,9 +33,9 @@ public class UserPreferencesDao
 	}
 
 	/**
-	 * @return	a key-value map of the user preferences
+	 * @return a key-value map of the user preferences
 	 * @throws OsmAuthorizationException if the application is not authenticated to read the
-	 *                                     user's preferences. (Permission.READ_PREFERENCES_AND_USER_DETAILS) */
+	 *                                   user's preferences. (Permission.READ_PREFERENCES_AND_USER_DETAILS) */
 	public Map<String,String> getAll()
 	{
 		return osm.makeAuthenticatedRequest(USERPREFS, "GET", new PreferencesParser());
@@ -45,7 +46,7 @@ public class UserPreferencesDao
 	 * @return	the value of the given preference or null if the preference does not exist
 	 *
 	 * @throws	OsmAuthorizationException if the application is not authenticated to read the
-	 *                                     user's preferences. (Permission.READ_PREFERENCES_AND_USER_DETAILS) */
+	 *                                   user's preferences. (Permission.READ_PREFERENCES_AND_USER_DETAILS) */
 	public String get(String key)
 	{
 		String urlKey = urlEncode(key);
@@ -75,7 +76,7 @@ public class UserPreferencesDao
 	 *                    characters.
 	 *
 	 * @throws OsmAuthorizationException if this application is not authorized to change the
-	 *                                    user's preferences. (Permission.CHANGE_PREFERENCES)
+	 *                                   user's preferences. (Permission.CHANGE_PREFERENCES)
 	 */
 	public void setAll(Map<String, String> preferences)
 	{
@@ -117,7 +118,7 @@ public class UserPreferencesDao
 	 * @param value preference to set. Must be less than 256 characters.
 	 *
 	 * @throws OsmAuthorizationException if this application is not authorized to change the
-	 *                                    user's preferences. (Permission.CHANGE_PREFERENCES)
+	 *                                   user's preferences. (Permission.CHANGE_PREFERENCES)
 	 */
 	public void set(String key, String value)
 	{
@@ -133,7 +134,7 @@ public class UserPreferencesDao
 	 *
 	 * @param key preference to delete. Must be less than 256 characters.
 	 * @throws OsmAuthorizationException if this application is not authorized to change the
-	 *                                    user's preferences. (Permission.CHANGE_PREFERENCES)
+	 *                                   user's preferences. (Permission.CHANGE_PREFERENCES)
 	 */
 	public void delete(String key)
 	{

--- a/src/test/java/de/westnordost/osmapi/changesets/ChangesetsDaoTest.java
+++ b/src/test/java/de/westnordost/osmapi/changesets/ChangesetsDaoTest.java
@@ -11,6 +11,7 @@ import de.westnordost.osmapi.OsmConnection;
 import de.westnordost.osmapi.common.Handler;
 import de.westnordost.osmapi.common.errors.OsmAuthorizationException;
 import de.westnordost.osmapi.common.errors.OsmNotFoundException;
+import de.westnordost.osmapi.map.changes.MapDataChangesHandler;
 import de.westnordost.osmapi.map.data.Element;
 import de.westnordost.osmapi.map.MapDataDao;
 import de.westnordost.osmapi.map.data.Node;
@@ -174,6 +175,13 @@ public class ChangesetsDaoTest extends TestCase
 		try
 		{
 			anonymousDao.get(changesetId);
+			fail();
+		}
+		catch(OsmAuthorizationException e) {}
+
+		try
+		{
+			anonymousDao.getData(123, new SimpleMapDataChangesHandler());
 			fail();
 		}
 		catch(OsmAuthorizationException e) {}

--- a/src/test/java/de/westnordost/osmapi/notes/NotesDaoTest.java
+++ b/src/test/java/de/westnordost/osmapi/notes/NotesDaoTest.java
@@ -109,13 +109,6 @@ public class NotesDaoTest extends TestCase
 	{
 		try
 		{
-			unprivilegedDao.comment(note.id, TEXT, false);
-			fail();
-		}
-		catch(OsmAuthorizationException e) {}
-
-		try
-		{
 			unprivilegedDao.comment(note.id, TEXT);
 			fail();
 		}
@@ -193,13 +186,6 @@ public class NotesDaoTest extends TestCase
 			fail();
 		}
 		catch(IllegalArgumentException e) {}
-
-		try
-		{
-			privilegedDao.comment(note.id, "", false);
-			fail();
-		}
-		catch(IllegalArgumentException e) {}
 	}
 
 	public void testCommentNoteWithNullTextFails()
@@ -207,13 +193,6 @@ public class NotesDaoTest extends TestCase
 		try
 		{
 			privilegedDao.comment(note.id, null);
-			fail();
-		}
-		catch(NullPointerException e) {}
-
-		try
-		{
-			privilegedDao.comment(note.id, null, false);
 			fail();
 		}
 		catch(NullPointerException e) {}
@@ -359,7 +338,7 @@ public class NotesDaoTest extends TestCase
 
 	public void testGetNote()
 	{
-		Note note2 = anonymousDao.get(note.id);
+		Note note2 = unprivilegedDao.get(note.id);
 		assertEquals(note.id, note2.id);
 		assertEquals(note.status, note2.status);
 		assertEquals(note.comments.size(), note2.comments.size());
@@ -369,7 +348,17 @@ public class NotesDaoTest extends TestCase
 
 	public void testGetNoNote()
 	{
-		assertNull(anonymousDao.get(0));
+		assertNull(unprivilegedDao.get(0));
+	}
+
+	public void testGetNoteAsAnonymousFails()
+	{
+		try
+		{
+			anonymousDao.get(note.id);
+			fail();
+		}
+		catch (OsmAuthorizationException e) {}
 	}
 
 	public void testQueryTooBig()
@@ -413,8 +402,18 @@ public class NotesDaoTest extends TestCase
 	public void testGetNotes()
 	{
 		Counter counter = new Counter();
-		anonymousDao.getAll(MY_AREA, counter, 100, -1);
+		unprivilegedDao.getAll(MY_AREA, counter, 100, -1);
 		assertTrue(counter.count > 0);
+	}
+
+	public void testGetNotesAsAnonymousFails()
+	{
+		try
+		{
+			anonymousDao.getAll(MY_AREA, null, 100, -1);
+			fail();
+		}
+		catch(OsmAuthorizationException e) {}
 	}
 
 	public void testSearchNotes()

--- a/src/test/java/de/westnordost/osmapi/notes/NotesDaoTest.java
+++ b/src/test/java/de/westnordost/osmapi/notes/NotesDaoTest.java
@@ -91,13 +91,6 @@ public class NotesDaoTest extends TestCase
 	{
 		try
 		{
-			unprivilegedDao.create(POINT, TEXT, false);
-			fail();
-		}
-		catch(OsmAuthorizationException e) {}
-
-		try
-		{
 			unprivilegedDao.create(POINT, TEXT);
 			fail();
 		}
@@ -166,13 +159,6 @@ public class NotesDaoTest extends TestCase
 		try
 		{
 			privilegedDao.create(POINT, "");
-			fail();
-		}
-		catch(IllegalArgumentException e) {}
-
-		try
-		{
-			privilegedDao.create(POINT, "", false);
 			fail();
 		}
 		catch(IllegalArgumentException e) {}

--- a/src/test/java/de/westnordost/osmapi/user/UserDaoTest.java
+++ b/src/test/java/de/westnordost/osmapi/user/UserDaoTest.java
@@ -3,22 +3,25 @@ package de.westnordost.osmapi.user;
 import junit.framework.TestCase;
 import de.westnordost.osmapi.ConnectionTestFactory;
 import de.westnordost.osmapi.common.errors.OsmAuthorizationException;
+import de.westnordost.osmapi.notes.NotesDao;
 
 public class UserDaoTest extends TestCase
 {
 	private UserDao privilegedDao;
+	private NotesDao anonymousDao;
 	private UserDao unprivilegedDao;
 
 	@Override
 	protected void setUp()
 	{
+		anonymousDao = new NotesDao(ConnectionTestFactory.createConnection(null));
 		privilegedDao = new UserDao(ConnectionTestFactory.createConnection(
 				ConnectionTestFactory.User.ALLOW_EVERYTHING));
 		unprivilegedDao = new UserDao(ConnectionTestFactory.createConnection(
 				ConnectionTestFactory.User.ALLOW_NOTHING));
 	}
 
-	public void testGetUserDetailsUnprivileged()
+	public void testGetUserDetailsUnprivilegedFails()
 	{
 		try
 		{
@@ -28,7 +31,7 @@ public class UserDaoTest extends TestCase
 		catch(OsmAuthorizationException e)	{ }
 	}
 
-	public void testGetUserDetailsPrivileged()
+	public void testGetUserDetailsPrivilegedWorks()
 	{
 		// should just not throw any exceptions. Since the user details may change, we do not
 		// check the validity of the data here
@@ -39,5 +42,14 @@ public class UserDaoTest extends TestCase
 	{
 		assertNull(unprivilegedDao.get(0L));
 		assertNotNull(unprivilegedDao.get(1L));
+	}
+
+	public void testGetUserInfoAsAnonymousFails()
+	{
+		try
+		{
+			anonymousDao.get(0L);
+		}
+		catch (OsmAuthorizationException e) {}
 	}
 }


### PR DESCRIPTION
see https://wiki.openstreetmap.org/wiki/GDPR/Affected_Services

Mostly updating the documentation, testing that and making a few calls into authenticated requests.
## Changes
- map data: changeset information for the returned elements will only include user information if logged in; library now makes authenticated requests where possible - **without this change, the library will never return user information because it makes those requests not authenticated by default currently**
- map data history: same as map data
- notes: calls are now only allowed if logged in
- user info: calls are now only allowed if logged in

## To be determined:
- changeset/id/download still available without login (minus user data)?
- creating notes as anonymous still allowed?
- actually running the tests (will fail now obviously because openstreetmap-website is not updated in accordance to GDPR yet)