### PR TITLE
Use static hashCode() methods.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,6 @@ subprojects {
 
     group = "de.westnordost"
 
-    sourceCompatibility = 1.7
-    targetCompatibility = 1.7
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
 }

--- a/libs/core/src/main/java/de/westnordost/osmapi/map/data/OsmLatLon.java
+++ b/libs/core/src/main/java/de/westnordost/osmapi/map/data/OsmLatLon.java
@@ -53,19 +53,13 @@ public class OsmLatLon implements LatLon, Serializable
 	public boolean equals(Object obj)
 	{
 		if(obj == this) return true;
-		if(obj == null || !(obj instanceof LatLon)) return false;
+		if(!(obj instanceof LatLon)) return false;
 		LatLon other = (LatLon) obj;
 		return other.getLatitude() == getLatitude() && other.getLongitude() == getLongitude();
 	}
 
 	@Override public int hashCode()
 	{
-		return 31 * hashCode(latitude) + hashCode(longitude);
-	}
-
-	private static int hashCode(double val)
-	{
-		long longBits = Double.doubleToLongBits(val);
-		return (int) (longBits ^ (longBits >>> 32));
+		return 31 * Double.hashCode(latitude) + Double.hashCode(longitude);
 	}
 }

--- a/libs/map/src/main/java/de/westnordost/osmapi/map/data/OsmRelationMember.java
+++ b/libs/map/src/main/java/de/westnordost/osmapi/map/data/OsmRelationMember.java
@@ -81,7 +81,7 @@ public class OsmRelationMember implements RelationMember, Serializable
 		int result = 11;
 		result = 31 * result + role.hashCode();
 		result = 31 * result + type.ordinal();
-		result = 31 * result + (int) (ref ^ (ref >>> 32));
+		result = 31 * result + Long.hashCode(ref);
 		return result;
 	}
 }


### PR DESCRIPTION
The static `hashCode()` methods introduced in Java 8 are [desugared](https://jakewharton.com/d8-library-desugaring/#kotlins-java-8) in Android projects using Android Gradle plugin 3.4 or higher and with Java 8 support enabled.

![Screenshot 2020-10-26 184645](https://user-images.githubusercontent.com/31027858/97176975-bcdf3500-17bb-11eb-849c-89f620259ee1.png)
