### PR TITLE
replace oauth 1.0a with oauth 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,18 +16,18 @@ Depending on which part of the API you use, you can only include what you need:
 
 <table>
 <tr><th>Class</th><th>Dependency</th><th>Description</th></tr>
-<tr><td>CapabilitiesApi</td><td><pre>de.westnordost:osmapi-core:2.0</pre></td><td>Getting server capabilities</td></tr>
-<tr><td>PermissionsApi</td><td><pre>de.westnordost:osmapi-core:2.0</pre></td><td>Getting user permissions</td></tr>
-<tr><td>MapDataApi</td><td><pre>de.westnordost:osmapi-map:2.3</pre></td><td>Getting map data, querying single elements and their relations toward each other and uploading changes in changesets</td></tr>
-<tr><td>MapDataHistoryApi</td><td><pre>de.westnordost:osmapi-map:2.3</pre></td><td>Getting the history and specific versions of elements</td></tr>
-<tr><td>NotesApi</td><td><pre>de.westnordost:osmapi-notes:2.0</pre></td><td>Getting finding, creating, commenting on and solving notes</td></tr>
-<tr><td>GpsTracesApi</td><td><pre>de.westnordost:osmapi-traces:2.0</pre></td><td>Getting, uploading, updating and deleting GPS traces and trackpoints</td></tr>
-<tr><td>ChangesetsApi</td><td><pre>de.westnordost:osmapi-changesets:2.3</pre></td><td>Finding changesets, changeset discussion, subscription and data</td></tr>
-<tr><td>UserApi</td><td><pre>de.westnordost:osmapi-user:2.0</pre></td><td>Getting user information</td></tr>
-<tr><td>UserPreferencesApi</td><td><pre>de.westnordost:osmapi-user:2.0</pre></td><td>Managing user preferences</td></tr>
+<tr><td>CapabilitiesApi</td><td><pre>de.westnordost:osmapi-core:3.0</pre></td><td>Getting server capabilities</td></tr>
+<tr><td>PermissionsApi</td><td><pre>de.westnordost:osmapi-core:3.0</pre></td><td>Getting user permissions</td></tr>
+<tr><td>MapDataApi</td><td><pre>de.westnordost:osmapi-map:3.0</pre></td><td>Getting map data, querying single elements and their relations toward each other and uploading changes in changesets</td></tr>
+<tr><td>MapDataHistoryApi</td><td><pre>de.westnordost:osmapi-map:3.0</pre></td><td>Getting the history and specific versions of elements</td></tr>
+<tr><td>NotesApi</td><td><pre>de.westnordost:osmapi-notes:3.0</pre></td><td>Getting finding, creating, commenting on and solving notes</td></tr>
+<tr><td>GpsTracesApi</td><td><pre>de.westnordost:osmapi-traces:3.0</pre></td><td>Getting, uploading, updating and deleting GPS traces and trackpoints</td></tr>
+<tr><td>ChangesetsApi</td><td><pre>de.westnordost:osmapi-changesets:3.0</pre></td><td>Finding changesets, changeset discussion, subscription and data</td></tr>
+<tr><td>UserApi</td><td><pre>de.westnordost:osmapi-user:3.0</pre></td><td>Getting user information</td></tr>
+<tr><td>UserPreferencesApi</td><td><pre>de.westnordost:osmapi-user:3.0</pre></td><td>Managing user preferences</td></tr>
 </table>
 
-To include everything, add [`de.westnordost:osmapi:4.3`](https://mvnrepository.com/artifact/de.westnordost/osmapi/4.0) as a Maven dependency or download the jar from there.
+To include everything, add [`de.westnordost:osmapi:5.0`](https://mvnrepository.com/artifact/de.westnordost/osmapi/4.0) as a Maven dependency or download the jar from there.
 
 ### Android
 
@@ -35,7 +35,7 @@ On Android, you need to exclude kxml2 from the dependencies since it is already 
 
 ```gradle
 dependencies {
-    implementation 'de.westnordost:osmapi:4.3'
+    implementation 'de.westnordost:osmapi:5.0'
 }
 
 configurations {

--- a/README.md
+++ b/README.md
@@ -31,32 +31,19 @@ To include everything, add [`de.westnordost:osmapi:5.0`](https://mvnrepository.c
 
 ### Android
 
-On Android, you need to exclude kxml2 from the dependencies since it is already built-in, like so:
+On Android, you need to exclude kxml2 from the dependencies in your `gradle.kts` since it is already built-in, like so:
 
-```gradle
-dependencies {
-    implementation 'de.westnordost:osmapi:5.0'
-}
-
+```kotlin
 configurations {
-    // already included in Android
-    all*.exclude group: 'net.sf.kxml', module: 'kxml2'
-    
-    // @NonNull etc annotations are also already included in Android
-    cleanedAnnotations
-    compile.exclude group: 'org.jetbrains', module:'annotations'
-    compile.exclude group: 'com.intellij', module:'annotations'
-    compile.exclude group: 'org.intellij', module:'annotations'
-    compile.exclude group: 'xmlpull', module:'xmlpull'
+    all {
+        // it's already included in Android
+        exclude(group = "net.sf.kxml", module = "kxml2")
+        exclude(group = "xmlpull", module = "xmlpull")
+    }
 }
 ```
 
-Also, starting with v4.0 (or v2.0 of the modularized version respectively), this library uses the classes from the Java 8 time API, like [`Instant`](https://developer.android.com/reference/java/time/Instant) etc. instead of `Date` which [leads to about 50% faster parsing times](https://github.com/streetcomplete/StreetComplete/discussions/2740) when receiving a result.
-
-If your app supports Android API levels below 26, you have two options:
-
-1. Either stick to using version 3.x (or v1.x of the modularized version respectively) of this library...
-2. ...or enable [Java 8+ API desugaring support](https://developer.android.com/studio/write/java8-support#library-desugaring) for your app
+This library uses classes from the Java 8 time API, like [`Instant`](https://developer.android.com/reference/java/time/Instant) etc., so if your app supports Android API levels below 26, you need to enable [Java 8+ API desugaring support](https://developer.android.com/studio/write/java8-support#library-desugaring).
 
 ## Basic Usage
 
@@ -70,7 +57,7 @@ If you plan to make calls that can only be made by a logged in user, such as upl
     );
 ```
 
-You can call osm.makeRequest(...) yourself to talk with the RESTful Api and write your own ApiRequestWriter and ApiResponseReader to write/read the request.
+You can call `osm.makeRequest(...)` yourself to talk with the RESTful Api and write your own ApiRequestWriter and ApiResponseReader to write/read the request.
 It is more convenient however to use the appropriate class to do that for you and return the data you are interested in. See the table above for which classes are available.
 
 For example...

--- a/build.gradle
+++ b/build.gradle
@@ -13,11 +13,11 @@ subprojects {
 }
 
 ext {
-    all_version = 4.3
-    core_version = 2.0
-    changesets_version = 2.3
-    user_version = 2.0
-    traces_version = 2.0
-    notes_version = 2.0
-    map_version = 2.3
+    all_version = 5.0
+    core_version = 3.0
+    changesets_version = 3.0
+    user_version = 3.0
+    traces_version = 3.0
+    notes_version = 3.0
+    map_version = 3.0
 }

--- a/libs/changesets/src/main/java/de/westnordost/osmapi/changesets/ChangesetsApi.java
+++ b/libs/changesets/src/main/java/de/westnordost/osmapi/changesets/ChangesetsApi.java
@@ -37,7 +37,7 @@ public class ChangesetsApi
 		String query = CHANGESET + "/" + id + "?include_discussion=true";
 		try
 		{
-			boolean authenticate = osm.getOAuth() != null;
+			boolean authenticate = osm.getOAuthAccessToken() != null;
 			osm.makeRequest(query, authenticate, new ChangesetParser(handler));
 		}
 		catch(OsmNotFoundException e)
@@ -59,7 +59,7 @@ public class ChangesetsApi
 		String query = filters != null ? "?" + filters.toParamString() : "";
 		try
 		{
-			boolean authenticate = osm.getOAuth() != null;
+			boolean authenticate = osm.getOAuthAccessToken() != null;
 			osm.makeRequest(CHANGESET + "s" + query, authenticate, new ChangesetParser(handler));
 		}
 		catch(OsmNotFoundException e)
@@ -196,7 +196,7 @@ public class ChangesetsApi
 	 */
 	public void getData(long id, MapDataChangesHandler handler, MapDataFactory factory)
 	{
-		boolean authenticate = osm.getOAuth() != null;
+		boolean authenticate = osm.getOAuthAccessToken() != null;
 		osm.makeRequest(CHANGESET + "/" + id + "/download", authenticate, new MapDataChangesParser(handler, factory));
 	}
 }

--- a/libs/core/build.gradle
+++ b/libs/core/build.gradle
@@ -3,7 +3,6 @@ version = core_version
 description = 'Client for the OSM API 0.6 - Core functionality, getting server capabilities, getting user permissions'
 
 dependencies {
-    compile 'oauth.signpost:signpost-core:2.1.1'
     compile 'xmlpull:xmlpull:1.1.3.1'
     runtime 'net.sf.kxml:kxml2:2.3.0'
 }

--- a/libs/core/src/test/java/de/westnordost/osmapi/OsmConnectionTest.java
+++ b/libs/core/src/test/java/de/westnordost/osmapi/OsmConnectionTest.java
@@ -18,7 +18,7 @@ public class OsmConnectionTest
 		try
 		{
 			OsmConnection osm = ConnectionTestFactory.createConnection(null);
-			osm.makeAuthenticatedRequest("doesntMatter", "GET");
+			osm.makeAuthenticatedRequest("changeset/create", "PUT", null, null);
 			fail();
 		}
 		catch(OsmAuthorizationException ignore) {}

--- a/libs/map/src/main/java/de/westnordost/osmapi/map/MapDataApi.java
+++ b/libs/map/src/main/java/de/westnordost/osmapi/map/MapDataApi.java
@@ -213,7 +213,7 @@ public class MapDataApi
 		}
 
 		String request = "map?bbox=" + bounds.getAsLeftBottomRightTopString();
-		boolean authenticate = osm.getOAuth() != null;
+		boolean authenticate = osm.getOAuthAccessToken() != null;
 
 		try
 		{
@@ -235,7 +235,7 @@ public class MapDataApi
 	 *  @throws OsmNotFoundException if the way with the given id does not exist */
 	public void getWayComplete(long id, MapDataHandler handler)
 	{
-		boolean authenticate = osm.getOAuth() != null;
+		boolean authenticate = osm.getOAuthAccessToken() != null;
 		osm.makeRequest(WAY + "/" + id + "/" + FULL, authenticate, new MapDataParser(handler, factory));
 	}
 
@@ -249,7 +249,7 @@ public class MapDataApi
 	 *  @throws OsmNotFoundException if the relation with the given id does not exist*/
 	public void getRelationComplete(long id, MapDataHandler handler)
 	{
-		boolean authenticate = osm.getOAuth() != null;
+		boolean authenticate = osm.getOAuthAccessToken() != null;
 		osm.makeRequest(RELATION + "/" + id + "/" + FULL, authenticate, new MapDataParser(handler, factory));
 	}
 
@@ -285,7 +285,7 @@ public class MapDataApi
 		SingleOsmElementHandler<T> handler = new SingleOsmElementHandler<>(tClass);
 		try
 		{
-			boolean authenticate = osm.getOAuth() != null;
+			boolean authenticate = osm.getOAuthAccessToken() != null;
 			osm.makeRequest(call, authenticate, new MapDataParser(handler, factory));
 		}
 		catch(OsmNotFoundException e)
@@ -382,7 +382,7 @@ public class MapDataApi
 	private <T extends Element> List<T> getSomeElements(String call, Class<T> tClass)
 	{
 		ListOsmElementHandler<T> handler = new ListOsmElementHandler<>(tClass);
-		boolean authenticate = osm.getOAuth() != null;
+		boolean authenticate = osm.getOAuthAccessToken() != null;
 		osm.makeRequest(call, authenticate, new MapDataParser(handler, factory));
 		return handler.get();
 	}

--- a/libs/map/src/main/java/de/westnordost/osmapi/map/MapDataHistoryApi.java
+++ b/libs/map/src/main/java/de/westnordost/osmapi/map/MapDataHistoryApi.java
@@ -49,7 +49,7 @@ public class MapDataHistoryApi
 	public void getNodeHistory(long id, Handler<Node> handler)
 	{
 		MapDataHandler mapDataHandler = new WrapperOsmElementHandler<>(Node.class, handler);
-		boolean authenticate = osm.getOAuth() != null;
+		boolean authenticate = osm.getOAuthAccessToken() != null;
 		osm.makeRequest(NODE + "/" + id + "/" + HISTORY, authenticate,
 				new MapDataParser(mapDataHandler, factory));
 	}
@@ -65,7 +65,7 @@ public class MapDataHistoryApi
 	public void getWayHistory(long id, Handler<Way> handler)
 	{
 		MapDataHandler mapDataHandler = new WrapperOsmElementHandler<>(Way.class, handler);
-		boolean authenticate = osm.getOAuth() != null;
+		boolean authenticate = osm.getOAuthAccessToken() != null;
 		osm.makeRequest(WAY + "/" + id + "/" + HISTORY, authenticate,
 				new MapDataParser(mapDataHandler, factory));
 	}
@@ -81,7 +81,7 @@ public class MapDataHistoryApi
 	public void getRelationHistory(long id, Handler<Relation> handler)
 	{
 		MapDataHandler mapDataHandler = new WrapperOsmElementHandler<>(Relation.class, handler);
-		boolean authenticate = osm.getOAuth() != null;
+		boolean authenticate = osm.getOAuthAccessToken() != null;
 		osm.makeRequest(RELATION + "/" + id + "/" + HISTORY, authenticate,
 				new MapDataParser(mapDataHandler, factory));
 	}
@@ -127,7 +127,7 @@ public class MapDataHistoryApi
 		SingleOsmElementHandler<T> handler = new SingleOsmElementHandler<>(tClass);
 		try
 		{
-			boolean authenticate = osm.getOAuth() != null;
+			boolean authenticate = osm.getOAuthAccessToken() != null;
 			osm.makeRequest(call, authenticate, new MapDataParser(handler, factory));
 		}
 		catch(OsmApiException e)

--- a/libs/notes/src/main/java/de/westnordost/osmapi/notes/NotesApi.java
+++ b/libs/notes/src/main/java/de/westnordost/osmapi/notes/NotesApi.java
@@ -58,7 +58,7 @@ public class NotesApi
 				"&text=" + urlEncode(text);
 		String call = NOTES + "?" + data;
 
-		boolean authenticate = osm.getOAuth() != null;
+		boolean authenticate = osm.getOAuthAccessToken() != null;
 		SingleElementHandler<Note> noteHandler = new SingleElementHandler<>();
 		osm.makeRequest(call, "POST", authenticate, null, new NotesParser(noteHandler));
 		return noteHandler.get();
@@ -157,7 +157,7 @@ public class NotesApi
 		SingleElementHandler<Note> noteHandler = new SingleElementHandler<>();
 		try
 		{
-			boolean authenticate = osm.getOAuth() != null;
+			boolean authenticate = osm.getOAuthAccessToken() != null;
 			osm.makeRequest(NOTES + "/" + id, authenticate, new NotesParser(noteHandler));
 		}
 		catch (OsmNotFoundException e)
@@ -216,7 +216,7 @@ public class NotesApi
 
 		try
 		{
-			boolean authenticate = osm.getOAuth() != null;
+			boolean authenticate = osm.getOAuthAccessToken() != null;
 			osm.makeRequest(call, authenticate, new NotesParser(handler));
 		}
 		catch(OsmBadUserInputException e)
@@ -238,7 +238,7 @@ public class NotesApi
 	public void find(Handler<Note> handler, QueryNotesFilters filters)
 	{
 		String query = filters != null ? "?" + filters.toParamString() : "";
-		boolean authenticate = osm.getOAuth() != null;
+		boolean authenticate = osm.getOAuthAccessToken() != null;
 		try {
 			osm.makeRequest(NOTES + "/search" + query, authenticate, new NotesParser(handler));
 		}

--- a/libs/notes/src/test/java/de/westnordost/osmapi/notes/NotesApiTest.java
+++ b/libs/notes/src/test/java/de/westnordost/osmapi/notes/NotesApiTest.java
@@ -7,7 +7,6 @@ import org.junit.Test;
 import java.time.Instant;
 import java.util.List;
 
-import oauth.signpost.exception.OAuthExpectationFailedException;
 import de.westnordost.osmapi.ConnectionTestFactory;
 import de.westnordost.osmapi.common.Handler;
 import de.westnordost.osmapi.common.errors.OsmAuthorizationException;
@@ -153,10 +152,7 @@ public class NotesApiTest
 			anonymousApi.reopen(note.id, TEXT);
 			fail();
 		}
-		catch(OsmAuthorizationException e)
-		{
-			assertTrue(e.getCause() instanceof OAuthExpectationFailedException);
-		}
+		catch(OsmAuthorizationException ignore) { }
 	}
 
 	@Test public void closeNoteAsAnonymousFails()
@@ -166,10 +162,7 @@ public class NotesApiTest
 			anonymousApi.close(note.id, TEXT);
 			fail();
 		}
-		catch(OsmAuthorizationException e)
-		{
-			assertTrue(e.getCause() instanceof OAuthExpectationFailedException);
-		}
+		catch(OsmAuthorizationException ignore) { }
 	}
 
 	@Test public void createNoteWithoutTextFails()

--- a/libs/traces/src/test/java/de/westnordost/osmapi/traces/GpsTracesApiTest.java
+++ b/libs/traces/src/test/java/de/westnordost/osmapi/traces/GpsTracesApiTest.java
@@ -26,7 +26,7 @@ public class GpsTracesApiTest
 	
 	private static final int NONEXISTING_TRACE = 0;
 
-	private static final int PRIVATE_TRACE_OF_OTHER_USER = 928;
+	private static final int PRIVATE_TRACE_OF_OTHER_USER = 23;
 	private static final int PUBLIC_TRACE = 927;
 
 	
@@ -196,7 +196,7 @@ public class GpsTracesApiTest
 		assertEquals("test case desc", trace.description);
 		assertTrue(trace.tags.contains("a tag"));
 		assertTrue(trace.tags.contains("another"));
-		assertEquals("osmagent-test-allow-everything", trace.userName);
+		assertEquals("westnordost", trace.userName);
 		assertTrue(Math.abs(Instant.now().toEpochMilli() - trace.createdAt.toEpochMilli()) < TEN_MINUTES);
 
 		privilegedApi.update(id, Visibility.TRACKABLE, "desc", null);

--- a/libs/user/src/main/java/de/westnordost/osmapi/user/UserApi.java
+++ b/libs/user/src/main/java/de/westnordost/osmapi/user/UserApi.java
@@ -40,7 +40,7 @@ public class UserApi
 		try
 		{
 			SingleElementHandler<UserInfo> handler = new SingleElementHandler<>();
-			boolean authenticate = osm.getOAuth() != null;
+			boolean authenticate = osm.getOAuthAccessToken() != null;
 			osm.makeRequest("user/" + userId, authenticate, new UserInfoParser(handler));
 			return handler.get();
 		}
@@ -54,7 +54,7 @@ public class UserApi
 	{
 		if(userIds.isEmpty()) return Collections.emptyList();
 		ListHandler<UserInfo> handler = new ListHandler<>();
-		boolean authenticate = osm.getOAuth() != null;
+		boolean authenticate = osm.getOAuthAccessToken() != null;
 		osm.makeRequest("users?users=" + toCommaList(userIds), authenticate, new UserInfoParser(handler));
 		return handler.get();
 	}

--- a/testutils/src/main/java/de/westnordost/osmapi/ConnectionTestFactory.java
+++ b/testutils/src/main/java/de/westnordost/osmapi/ConnectionTestFactory.java
@@ -1,12 +1,23 @@
 package de.westnordost.osmapi;
 
-import oauth.signpost.OAuthConsumer;
-import oauth.signpost.basic.DefaultOAuthConsumer;
-
 public class ConnectionTestFactory
 {
-	private static final String CONSUMER_KEY = "CuPCn3sRc8FDiepAoSkH4a9n7w2QuqVCykStfVPG";
-	private static final String CONSUMER_SECRET = "D1nX6BF1NMAZtIq8ouGJJ7zGtSaTRDTz8QfZl5mo";
+	private static final String CLIENT_ID = "_RN0elf1uUxGvpdRQram0s_hfPpOkimHVXhlHN5Cx5I";
+	private static final String CLIENT_SECRET = "UN8rnr9zSni1504KUeTi4iFwUnErW3YyhMEIaEg0Q-E";
+
+	// to request new token:
+	// 1. GET https://master.apis.dev.openstreetmap.org/oauth2/authorize?response_type=code&client_id=_RN0elf1uUxGvpdRQram0s_hfPpOkimHVXhlHN5Cx5I&redirect_uri=https://127.0.0.1/oauth&scope=read_prefs%20write_prefs%20write_diary%20write_api%20read_gpx%20write_gpx%20write_notes
+	// 2. get the CODE from the url
+	// 3. POST 'https://master.apis.dev.openstreetmap.org/oauth2/token?grant_type=authorization_code&code=<CODE>&client_id=_RN0elf1uUxGvpdRQram0s_hfPpOkimHVXhlHN5Cx5I&redirect_uri=https://127.0.0.1/oauth'
+	private static final String ALLOW_EVERYTHING_TOKEN = "qzaxWiG2tprF1IfEcwf4-mn7Al4f2lsM3CNrvGEaIL0";
+
+	// to request new token:
+	// 1. GET https://master.apis.dev.openstreetmap.org/oauth2/authorize?response_type=code&client_id=_RN0elf1uUxGvpdRQram0s_hfPpOkimHVXhlHN5Cx5I&redirect_uri=https://127.0.0.1/oauth&scope=read_prefs
+	// 2. get the CODE from the url
+	// 3. POST 'https://master.apis.dev.openstreetmap.org/oauth2/token?grant_type=authorization_code&code=<CODE>&client_id=_RN0elf1uUxGvpdRQram0s_hfPpOkimHVXhlHN5Cx5I&redirect_uri=https://127.0.0.1/oauth'
+	private static final String ALLOW_NOTHING_TOKEN = "fp2SjHKQ55rSdI2x4FN_s0wNUh67dgNbf9x3WdjCa5Y";
+
+	private static final String UNKNOWN_TOKEN = "unknown";
 
 	private static final String TEST_API_URL = "https://master.apis.dev.openstreetmap.org/api/0.6/";
 
@@ -26,39 +37,14 @@ public class ConnectionTestFactory
 
 	public static OsmConnection createConnection(User user)
 	{
-		OAuthConsumer consumer = null;
-
+		String accessToken = "";
 		if(user == User.ALLOW_EVERYTHING)
-			consumer = createConsumerThatAllowsEverything();
+			accessToken = ALLOW_EVERYTHING_TOKEN;
 		else if(user == User.ALLOW_NOTHING)
-			consumer = createConsumerThatProhibitsEverything();
+			accessToken = ALLOW_NOTHING_TOKEN;
 		else if(user == User.UNKNOWN)
-			consumer = createUnknownUser();
+			accessToken = UNKNOWN_TOKEN;
 
-		return new OsmConnection(TEST_API_URL, USER_AGENT, consumer);
-	}
-
-
-	private static OAuthConsumer createConsumerThatProhibitsEverything()
-	{
-		OAuthConsumer result = new DefaultOAuthConsumer(CONSUMER_KEY, CONSUMER_SECRET);
-		result.setTokenWithSecret(
-				"RCamNf4TT7uNeFjmigvOUWhajp5ERFZmcN1qvi7a",
-				"72dzmAvuNBEOVKkif3JSYdzMlAq2dw5OnIG75dtX");
-		return result;
-	}
-
-	private static OAuthConsumer createConsumerThatAllowsEverything()
-	{
-		OAuthConsumer result = new DefaultOAuthConsumer(CONSUMER_KEY, CONSUMER_SECRET);
-		result.setTokenWithSecret(
-				"2C4LiOQBOn96kXHyal7uzMJiqpCsiyDBvb8pomyX",
-				"1bFMIQpgmu5yjywt3kknopQpcRmwJ6snDDGF7kdr");
-		return result;
-	}
-	
-	private static OAuthConsumer createUnknownUser()
-	{
-		return new DefaultOAuthConsumer(CONSUMER_KEY, CONSUMER_SECRET);
+		return new OsmConnection(TEST_API_URL, USER_AGENT, accessToken);
 	}
 }

--- a/testutils/src/main/java/de/westnordost/osmapi/ConnectionTestFactory.java
+++ b/testutils/src/main/java/de/westnordost/osmapi/ConnectionTestFactory.java
@@ -3,16 +3,17 @@ package de.westnordost.osmapi;
 public class ConnectionTestFactory
 {
 	private static final String CLIENT_ID = "_RN0elf1uUxGvpdRQram0s_hfPpOkimHVXhlHN5Cx5I";
+	// actually not used anywhere. Only necessary to request a token if app was registered as "confidential"
 	private static final String CLIENT_SECRET = "UN8rnr9zSni1504KUeTi4iFwUnErW3YyhMEIaEg0Q-E";
 
 	// to request new token:
-	// 1. GET https://master.apis.dev.openstreetmap.org/oauth2/authorize?response_type=code&client_id=_RN0elf1uUxGvpdRQram0s_hfPpOkimHVXhlHN5Cx5I&redirect_uri=https://127.0.0.1/oauth&scope=read_prefs%20write_prefs%20write_diary%20write_api%20read_gpx%20write_gpx%20write_notes
+	// 1. open in browser https://master.apis.dev.openstreetmap.org/oauth2/authorize?response_type=code&client_id=_RN0elf1uUxGvpdRQram0s_hfPpOkimHVXhlHN5Cx5I&redirect_uri=https://127.0.0.1/oauth&scope=read_prefs%20write_prefs%20write_diary%20write_api%20read_gpx%20write_gpx%20write_notes
 	// 2. get the CODE from the url
 	// 3. POST 'https://master.apis.dev.openstreetmap.org/oauth2/token?grant_type=authorization_code&code=<CODE>&client_id=_RN0elf1uUxGvpdRQram0s_hfPpOkimHVXhlHN5Cx5I&redirect_uri=https://127.0.0.1/oauth'
 	private static final String ALLOW_EVERYTHING_TOKEN = "qzaxWiG2tprF1IfEcwf4-mn7Al4f2lsM3CNrvGEaIL0";
 
 	// to request new token:
-	// 1. GET https://master.apis.dev.openstreetmap.org/oauth2/authorize?response_type=code&client_id=_RN0elf1uUxGvpdRQram0s_hfPpOkimHVXhlHN5Cx5I&redirect_uri=https://127.0.0.1/oauth&scope=read_prefs
+	// 1. open in browser https://master.apis.dev.openstreetmap.org/oauth2/authorize?response_type=code&client_id=_RN0elf1uUxGvpdRQram0s_hfPpOkimHVXhlHN5Cx5I&redirect_uri=https://127.0.0.1/oauth&scope=read_prefs
 	// 2. get the CODE from the url
 	// 3. POST 'https://master.apis.dev.openstreetmap.org/oauth2/token?grant_type=authorization_code&code=<CODE>&client_id=_RN0elf1uUxGvpdRQram0s_hfPpOkimHVXhlHN5Cx5I&redirect_uri=https://127.0.0.1/oauth'
 	private static final String ALLOW_NOTHING_TOKEN = "fp2SjHKQ55rSdI2x4FN_s0wNUh67dgNbf9x3WdjCa5Y";


### PR DESCRIPTION
fixes openstreetmap/openstreetmap-website#33

the ALLOW_NOTHING_TOKEN is only preliminary because due to https://github.com/openstreetmap/operations/issues/1002 it is not possible to create a token that has no permissions

Once the mentioned issue is solved, new tokens must be generated and put into the test codes. Then, all the tests will pass.